### PR TITLE
Action retargeting fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,141 @@
+*.json
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+out/
+# C extensions
+*.so
+*.pkl
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+distf/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+wandb/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+.vscode/*
+.vscode/settings.json
+
+
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+# target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+venv/
+env.bak/
+venv.bak/
+ 
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+ # Pyre type checker
+.pyre/
+checkpoints/
+data/*
+output/
+log/
+runs/
+
+*.png
+*.jpg
+*.mp4
+*.gif
+*.pkl
+*.pt

--- a/docker/requirements_blender.txt
+++ b/docker/requirements_blender.txt
@@ -1,5 +1,5 @@
-torch==1.12.1
-torchvision==0.13.1
+torch==2.2.0
+torchvision==0.17.0
 tqdm==4.62.3
 unfoldNd==0.2.0
 pyyaml>=5.3.1

--- a/utils/rename_mixamo_rig.py
+++ b/utils/rename_mixamo_rig.py
@@ -1,0 +1,8 @@
+# rename_mixamo_prefix.py
+import bpy, re
+rx = re.compile(r"mixamorig\d+:")          # any number before the colon
+
+for obj in bpy.data.objects:
+    if obj.type == 'ARMATURE':
+        for b in obj.data.bones:
+            b.name = rx.sub("mixamorig:", b.name)


### PR DESCRIPTION
### Summary
This PR fixes a critical issue that prevented action retargeting from working correctly due to mismatched rest pose handling.  
It also introduces a small feature in the add-on for Batch Generation.

### Changes
- **__init__.py**
  - Fixed incorrect XYZ handling in rest pose logic that caused mismatched rest poses, making action retargeting fail.
  - Added a new add-on feature to enable batch generation with a configurable number of outputs per run.
- **docker/requirements_blender.txt**
  - Updated dependencies to ensure Blender-related requirements install properly.
- **utils/rename_mixamo_rig.py**
  - Added a new utility script that provides an example of renaming Mixamo `.fbx` rigs for Blender compatibility.

### Testing
- Verified that action retargeting now works correctly on multiple Mixamo `.fbx` rigs inside Blender 3.6.
- Confirmed that batch generation produces the expected number of outputs per run.
- Ensured that updated dependencies install successfully inside the Docker environment.

### Additional Notes
This PR also adds a reference utility script (`rename_mixamo_rig.py`) to simplify rig renaming workflows for Mixamo rigs, which can serve as a template for other rigging cases.
